### PR TITLE
Add languages currently being translated

### DIFF
--- a/limetech/lang-ar_AR.xml
+++ b/limetech/lang-ar_AR.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Language>
+<LanguageURL>https://github.com/unraid/lang-ar_AR/archive/master.zip</LanguageURL>
+<Language>Arabic</Language>
+<LanguageLocal>عربى</LanguageLocal>
+<LanguagePack>ar_AR</LanguagePack>
+<RemoveFromCA>true</RemoveFromCA>
+<Author>....</Author>
+<Name>حزمة اللغة العربية</Name>
+<TemplateURL>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/lang-ar_AR.xml</TemplateURL>
+<Version>2020.06.24</Version>
+<Icon>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/Green-Earth-Transparent-File.png</Icon>
+<Description>
+هذه ترجمة عربية للمكونات الإضافية غير المدعومة
+
+This is an Arabic translation for Unraid and supported plugins
+</Description>
+</Language>

--- a/limetech/lang-lv_LV.xml
+++ b/limetech/lang-lv_LV.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Language>
+<LanguageURL>https://github.com/unraid/lang-lv_LV/archive/master.zip</LanguageURL>
+<Language>Latvian</Language>
+<LanguageLocal>Latvietis</LanguageLocal>
+<LanguagePack>lv_LV</LanguagePack>
+<RemoveFromCA>true</RemoveFromCA>
+<Author>....</Author>
+<Name>Latviešu valodas iepakojums</Name>
+<TemplateURL>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/lang-lv_LV.xml</TemplateURL>
+<Version>2020.06.24</Version>
+<Icon>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/Green-Earth-Transparent-File.png</Icon>
+<Description>
+šis ir tulkots latviešu valodas versijai Unraid un atbalstītajiem spraudņiem
+
+This is a Latvian translation for Unraid and supported plugins
+</Description>
+</Language>

--- a/limetech/lang-pl_PL.xml
+++ b/limetech/lang-pl_PL.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Language>
+<LanguageURL>https://github.com/unraid/lang-pl_PL/archive/master.zip</LanguageURL>
+<Language>Polish</Language>
+<LanguageLocal>Polskie</LanguageLocal>
+<LanguagePack>pl_PL</LanguagePack>
+<RemoveFromCA>true</RemoveFromCA>
+<Author>....</Author>
+<Name>Pakiet języka polskiego</Name>
+<TemplateURL>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/lang-pl_PL.xml</TemplateURL>
+<Version>2020.06.24</Version>
+<Icon>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/Green-Earth-Transparent-File.png</Icon>
+<Description>
+To jest polskie tłumaczenie dla Unraid i obsługiwanych wtyczek
+
+This is a Polish translation for Unraid and supported plugins
+</Description>
+</Language>

--- a/limetech/lang-pt_PT.xml
+++ b/limetech/lang-pt_PT.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Language>
+<LanguageURL>https://github.com/unraid/lang-pt_PT/archive/master.zip</LanguageURL>
+<Language>Portuguese</Language>
+<LanguageLocal>Português</LanguageLocal>
+<LanguagePack>pt_PT</LanguagePack>
+<RemoveFromCA>true</RemoveFromCA>
+<Author>....</Author>
+<Name>Pacote de idioma português</Name>
+<TemplateURL>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/lang-pt_PT.xml</TemplateURL>
+<Version>2020.06.24</Version>
+<Icon>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/Green-Earth-Transparent-File.png</Icon>
+<Description>
+Esta é uma tradução em português para Unraid e plugins suportados
+
+This is a Portuguese translation for Unraid and supported plugins
+</Description>
+</Language>

--- a/limetech/lang-sv_SE.xml
+++ b/limetech/lang-sv_SE.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Language>
+<LanguageURL>https://github.com/unraid/lang-sv_SE/archive/master.zip</LanguageURL>
+<Language>Swedish</Language>
+<LanguageLocal>svenska</LanguageLocal>
+<LanguagePack>sv_SE</LanguagePack>
+<RemoveFromCA>true</RemoveFromCA>
+<Author>....</Author>
+<Name>Svenska språkpaket</Name>
+<TemplateURL>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/lang-sv_SE.xml</TemplateURL>
+<Version>2020.06.24</Version>
+<Icon>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/Green-Earth-Transparent-File.png</Icon>
+<Description>
+Det här är en svensk översättning för instängda och stödda plugins
+
+This is a Swedish translation for Unraid and supported plugins
+</Description>
+</Language>

--- a/limetech/lang-zh_CN.xml
+++ b/limetech/lang-zh_CN.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Language>
+<LanguageURL>https://github.com/unraid/lang-zh_CN/archive/master.zip</LanguageURL>
+<Language>Mandarin</Language>
+<LanguageLocal>普通话</LanguageLocal>
+<LanguagePack>zh_CN</LanguagePack>
+<RemoveFromCA>true</RemoveFromCA>
+<Author>....</Author>
+<Name>普通话包</Name>
+<TemplateURL>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/lang-zh_CN.xml</TemplateURL>
+<Version>2020.06.24</Version>
+<Icon>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/Green-Earth-Transparent-File.png</Icon>
+<Description>
+这是Unraid和受支持的插件的中文翻译
+
+This is a Mandarin Chinese translation for Unraid and supported plugins
+</Description>
+</Language>


### PR DESCRIPTION
These additions will NOT show up in CA.  They are being added so that https://squidly271.github.io/languageErrors.html will keep track of the missing translations for all the languages so that once that link is published, community members can more easily contribute to the translations.

If / when the language is ready to be published (does not need to be 100% complete), then simply remove the RemoveFromCA line from the templates, and adjust everything else accordingly.

Don't criticize the job Google did on the translations ;)  - they can be changed at time of publishing.

NB: The generated link will get expanded a bit to include translations that are in en_US but not in the language repository until such time as the automated system works 100%