### PR TITLE
Stop hu_HU from appearing in CA

### DIFF
--- a/limetech/lang-hu_HU.xml
+++ b/limetech/lang-hu_HU.xml
@@ -6,6 +6,7 @@
 <LanguagePack>hu_HU</LanguagePack>
 <Author>Ármin Nyerges</Author>
 <Name>Magyar nyelvi csomag</Name>
+<RemoveFromCA>true</RemoveFromCA>
 <TemplateURL>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/lang-hu_HU.xml</TemplateURL>
 <Version>2022.02.14</Version>
 <Icon>https://raw.githubusercontent.com/unraid/language-templates/master/limetech/Green-Earth-Transparent-File.png</Icon>


### PR DESCRIPTION
The translations are currently blank.  Once it begins to actually have some translations, then revert this commit.  In the meantime it's completely pointless to have it available in CA